### PR TITLE
Add force_deploy command

### DIFF
--- a/lib/shipitron/cli.rb
+++ b/lib/shipitron/cli.rb
@@ -34,6 +34,30 @@ module Shipitron
       end
     end
 
+    desc 'force_deploy <app>', 'Forces a redeploy of the app'
+    option :config_file, default: 'shipitron/config.yml'
+    option :secrets_file, default: '~/.config/shipitron/secrets.yml'
+    option :debug, type: :boolean, default: false
+    def force_deploy(app)
+      setup(
+        config_file: options[:config_file],
+        secrets_file: options[:secrets_file]
+      )
+
+      require 'shipitron/client/force_deploy'
+      result = Client::ForceDeploy.call(
+        application: app
+      )
+
+      if result.failure?
+        result.errors.each do |error|
+          Logger.fatal error
+        end
+        Logger.fatal 'Deploy failed.'
+      end
+    end
+
+
     desc 'server_deploy', 'Server-side component of deploy'
     option :name, required: true
     option :repository, required: true

--- a/lib/shipitron/client/force_deploy.rb
+++ b/lib/shipitron/client/force_deploy.rb
@@ -1,5 +1,8 @@
 require 'shipitron'
 require 'shipitron/ecs_client'
+require 'shipitron/client/load_application_config'
+require 'shipitron/client/fetch_clusters'
+require 'shipitron/client/ensure_deploy_not_running'
 
 module Shipitron
   module Client

--- a/lib/shipitron/client/force_deploy.rb
+++ b/lib/shipitron/client/force_deploy.rb
@@ -1,0 +1,54 @@
+require 'shipitron'
+require 'shipitron/ecs_client'
+
+module Shipitron
+  module Client
+    class ForceDeploy
+      include Metaractor
+      include Interactor::Organizer
+      include EcsClient
+
+      required :application
+
+      organize [
+        LoadApplicationConfig,
+        FetchClusters,
+        EnsureDeployNotRunning
+      ]
+
+      def call
+        Logger.info "==> Force deploying #{application}"
+
+        super
+
+        context.clusters ||= []
+        context.ecs_services ||= []
+
+        begin
+          context.clusters.each do |cluster|
+            context.ecs_services.each do |service|
+              ecs_client(region: cluster.region).update_service(
+                cluster: cluster.name,
+                service: service,
+                force_new_deployment: true
+              )
+            end
+          end
+        rescue Aws::ECS::Errors::ServiceError => e
+          fail_with_errors!(messages: [
+            "Error: #{e.message}",
+            e.backtrace.join("\n")
+          ])
+        end
+
+        Logger.info "==> Done"
+      end
+
+      private
+      def application
+        context.application
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
The force_deploy command just hits ECS's `force_new_deployment` option.

https://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#update_service-instance_method