### PR TITLE
AR-774 Buildx/ECR support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apk add --no-cache \
     bash \
     curl \
     wget \
-    jq
+    jq \
+    aws-cli
 
 ENV ECR_CREDENTIAL_HELPER_VERSION 0.4.0
 RUN cd /usr/local/bin && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN cd /usr/local/bin && \
       wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECR_CREDENTIAL_HELPER_VERSION}/linux-amd64/docker-credential-ecr-login && \
       chmod +x docker-credential-ecr-login
 
-COPY --chown=shipitron:shipitron build_env/docker-config.json /home/shipitron/.docker/config.json
-
 USER shipitron
 ENV BUILDX_VERSION v0.4.1
 RUN cd /home/shipitron && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /usr/local/bin && \
       wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECR_CREDENTIAL_HELPER_VERSION}/linux-amd64/docker-credential-ecr-login && \
       chmod +x docker-credential-ecr-login
 
-ENV BUILDKIT_VERSION v0.7.1
+ENV BUILDKIT_VERSION v0.7.2
 RUN cd /usr/local/bin && \
       wget -nv https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz && \
       tar --strip-components=1 -zxvf buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz bin/buildctl && \
@@ -40,7 +40,7 @@ RUN cd /usr/local/bin && \
       rm -f buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 USER shipitron
-ENV BUILDX_VERSION v0.4.1
+ENV BUILDX_VERSION v0.4.2
 RUN cd /home/shipitron && \
       wget -nv https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64 && \
       mkdir -p ~/.docker/cli-plugins && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN apk add --no-cache \
     bash \
     curl \
     wget \
-    jq \
-    aws-cli
+    jq
 
 ENV ECR_CREDENTIAL_HELPER_VERSION 0.4.0
 RUN cd /usr/local/bin && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,22 @@ RUN apk add --no-cache \
     wget \
     jq
 
+ENV ECR_CREDENTIAL_HELPER_VERSION 0.4.0
+RUN cd /usr/local/bin && \
+      wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECR_CREDENTIAL_HELPER_VERSION}/linux-amd64/docker-credential-ecr-login && \
+      chmod +x docker-credential-ecr-login
+
+COPY --chown=shipitron:shipitron build_env/docker-config.json /home/shipitron/.docker/config.json
+
+USER shipitron
+ENV BUILDX_VERSION v0.4.1
+RUN cd /home/shipitron && \
+      wget -nv https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64 && \
+      mkdir -p ~/.docker/cli-plugins && \
+      mv buildx-${BUILDX_VERSION}.linux-amd64 ~/.docker/cli-plugins/docker-buildx && \
+      chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+USER root
 ENV USE_BUNDLE_EXEC true
 ENV BUNDLE_GEMFILE /shipitron/Gemfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ruby:2.6.6-alpine as cache
+FROM ruby:2.7.1-alpine as cache
 COPY cache/ /tmp/
 RUN   cd /usr/local/bundle && \
     ([ -f /tmp/bundler-data.tar.gz ] && \
     tar -zxf /tmp/bundler-data.tar.gz && \
     rm /tmp/bundler-data.tar.gz) || true
 
-FROM ruby:2.6.6-alpine
+FROM ruby:2.7.1-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
 RUN addgroup -S shipitron && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ruby:2.5.3-alpine3.8 as cache
+FROM ruby:2.6.6-alpine as cache
 COPY cache/ /tmp/
 RUN   cd /usr/local/bundle && \
     ([ -f /tmp/bundler-data.tar.gz ] && \
     tar -zxf /tmp/bundler-data.tar.gz && \
     rm /tmp/bundler-data.tar.gz) || true
 
-FROM ruby:2.5.3-alpine3.8
+FROM ruby:2.6.6-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
 RUN addgroup -S shipitron && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,13 @@ RUN cd /usr/local/bin && \
       wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECR_CREDENTIAL_HELPER_VERSION}/linux-amd64/docker-credential-ecr-login && \
       chmod +x docker-credential-ecr-login
 
+ENV BUILDKIT_VERSION v0.7.1
+RUN cd /usr/local/bin && \
+      wget -nv https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz && \
+      tar --strip-components=1 -zxvf buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz bin/buildctl && \
+      chmod +x buildctl && \
+      rm -f buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz
+
 USER shipitron
 ENV BUILDX_VERSION v0.4.1
 RUN cd /home/shipitron && \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-alpine
+FROM ruby:2.7.1-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
 RUN addgroup -S shipitron && \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-alpine3.8
+FROM ruby:2.6.6-alpine
 LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
 
 RUN addgroup -S shipitron && \

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'irb'

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ applications:
 - `dev run --rm -v /bin/docker:/bin/docker -v /var/run/docker.sock:/var/run/docker.sock shipitron server_deploy --name dummy-app --repository git@github.com:outstand/dummy-app --bucket outstand-shipitron --image-name outstand/dummy-app --region us-east-1 --cluster-name us-east-1-prod-blue --ecs-task-defs dummy-app --ecs-services dummy-app --build-script shipitron/build.sh --post-builds 'ecs_task:dummy-app,container_name:dummy-app,command:echo postbuild' --ecs-task-def-templates LS0tCmZhbWlseTogZHVtbXktYXBwCmNvbnRhaW5lcl9kZWZpbml0aW9uczoKICAtIG5hbWU6IGR1bW15LWFwcAogICAgaW1hZ2U6IG91dHN0YW5kL2R1bW15LWFwcDp7e3RhZ319CiAgICBtZW1vcnk6IDEyOAogICAgZXNzZW50aWFsOiB0cnVlCiAgICBwb3J0X21hcHBpbmdzOgogICAgICAtIGNvbnRhaW5lcl9wb3J0OiA4MAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gbmFtZTogU0VSVklDRV84MF9OQU1FCiAgICAgICAgdmFsdWU6IGR1bW15Cg== --ecs-service-templates LS0tCmNsdXN0ZXI6IHt7Y2x1c3Rlcn19CnNlcnZpY2VfbmFtZTogZHVtbXktYXBwCnRhc2tfZGVmaW5pdGlvbjogZHVtbXktYXBwe3tyZXZpc2lvbn19CmRlc2lyZWRfY291bnQ6IHt7Y291bnR9fQojcm9sZToge3tyb2xlfX0KZGVwbG95bWVudF9jb25maWd1cmF0aW9uOgogIG1heGltdW1fcGVyY2VudDogMjAwCiAgbWluaW11bV9oZWFsdGh5X3BlcmNlbnQ6IDUwCg== --debug` to run server side (dummy-app is an example)
 
 Running a dev version in production:
+- Update `Shipitron::Client::STARTED_BY`
 - `docker push outstand/shipitron:dev`
 - Update config to use `shipitron_task: shipitron-dev`
 - `dev run --rm shipitron deploy <app> --debug`

--- a/README.md
+++ b/README.md
@@ -33,18 +33,17 @@ applications:
 
 ## Development
 
-- `docker volume create --name shipitron_fog`
 - `./build_dev.sh`
-- `docker run -it --rm -v $(pwd):/shipitron -v shipitron_fog:/fog -e FOG_LOCAL=true -w /shipitron outstand/shipitron:dev rspec spec` to run specs
-- `APP_PATH=/path/to/app`
-- `docker run -it --rm -v $(pwd):/shipitron -v $HOME/.config/shipitron:/home/shipitron/.config/shipitron -v $APP_PATH:/app outstand/shipitron:dev deploy <app>` to run client side
-- `docker run -it --rm -v $(pwd):/shipitron -v $HOME/.config/shipitron:/home/shipitron/.config/shipitron -v $APP_PATH:/app outstand/shipitron:dev deploy <app> --simulate` to get the arguments for `server_deploy` below
-- `docker run -it --rm --dns 10.10.10.2 -v $(pwd):/shipitron -v $APP_PATH:/app -v /bin/docker:/bin/docker -v /var/run/docker.sock:/var/run/docker.sock -v shipitron_fog:/fog -e FOG_LOCAL=true -e CONSUL_HOST=consul outstand/shipitron:dev server_deploy --name dummy-app --repository git@github.com:outstand/dummy-app --bucket outstand-shipitron --image-name outstand/dummy-app --region us-east-1 --cluster-name us-east-1-prod-blue --ecs-task-defs dummy-app --ecs-services dummy-app --build-script shipitron/build.sh --post-builds 'ecs_task:dummy-app,container_name:dummy-app,command:echo postbuild' --ecs-task-def-templates LS0tCmZhbWlseTogZHVtbXktYXBwCmNvbnRhaW5lcl9kZWZpbml0aW9uczoKICAtIG5hbWU6IGR1bW15LWFwcAogICAgaW1hZ2U6IG91dHN0YW5kL2R1bW15LWFwcDp7e3RhZ319CiAgICBtZW1vcnk6IDEyOAogICAgZXNzZW50aWFsOiB0cnVlCiAgICBwb3J0X21hcHBpbmdzOgogICAgICAtIGNvbnRhaW5lcl9wb3J0OiA4MAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gbmFtZTogU0VSVklDRV84MF9OQU1FCiAgICAgICAgdmFsdWU6IGR1bW15Cg== --ecs-service-templates LS0tCmNsdXN0ZXI6IHt7Y2x1c3Rlcn19CnNlcnZpY2VfbmFtZTogZHVtbXktYXBwCnRhc2tfZGVmaW5pdGlvbjogZHVtbXktYXBwe3tyZXZpc2lvbn19CmRlc2lyZWRfY291bnQ6IHt7Y291bnR9fQojcm9sZToge3tyb2xlfX0KZGVwbG95bWVudF9jb25maWd1cmF0aW9uOgogIG1heGltdW1fcGVyY2VudDogMjAwCiAgbWluaW11bV9oZWFsdGh5X3BlcmNlbnQ6IDUwCg== --debug` to run server side (dummy-app is an example)
+- `dev run --rm shipitron_specs` to run specs
+- Set the application path in the volumes section in `docker-compose.yml`.
+- `dev run --rm shipitron deploy <app>` to run client side
+- `dev run --rm shipitron deploy <app> --simulate` to get the arguments for `server_deploy` below
+- `dev run --rm -v /bin/docker:/bin/docker -v /var/run/docker.sock:/var/run/docker.sock shipitron server_deploy --name dummy-app --repository git@github.com:outstand/dummy-app --bucket outstand-shipitron --image-name outstand/dummy-app --region us-east-1 --cluster-name us-east-1-prod-blue --ecs-task-defs dummy-app --ecs-services dummy-app --build-script shipitron/build.sh --post-builds 'ecs_task:dummy-app,container_name:dummy-app,command:echo postbuild' --ecs-task-def-templates LS0tCmZhbWlseTogZHVtbXktYXBwCmNvbnRhaW5lcl9kZWZpbml0aW9uczoKICAtIG5hbWU6IGR1bW15LWFwcAogICAgaW1hZ2U6IG91dHN0YW5kL2R1bW15LWFwcDp7e3RhZ319CiAgICBtZW1vcnk6IDEyOAogICAgZXNzZW50aWFsOiB0cnVlCiAgICBwb3J0X21hcHBpbmdzOgogICAgICAtIGNvbnRhaW5lcl9wb3J0OiA4MAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gbmFtZTogU0VSVklDRV84MF9OQU1FCiAgICAgICAgdmFsdWU6IGR1bW15Cg== --ecs-service-templates LS0tCmNsdXN0ZXI6IHt7Y2x1c3Rlcn19CnNlcnZpY2VfbmFtZTogZHVtbXktYXBwCnRhc2tfZGVmaW5pdGlvbjogZHVtbXktYXBwe3tyZXZpc2lvbn19CmRlc2lyZWRfY291bnQ6IHt7Y291bnR9fQojcm9sZToge3tyb2xlfX0KZGVwbG95bWVudF9jb25maWd1cmF0aW9uOgogIG1heGltdW1fcGVyY2VudDogMjAwCiAgbWluaW11bV9oZWFsdGh5X3BlcmNlbnQ6IDUwCg== --debug` to run server side (dummy-app is an example)
 
 Running a dev version in production:
 - `docker push outstand/shipitron:dev`
 - Update config to use `shipitron_task: shipitron-dev`
-- `docker run -it --rm -v $(pwd):/shipitron -v $HOME/.config/shipitron:/home/shipitron/.config/shipitron -v $APP_PATH:/app outstand/shipitron:dev deploy <app> --debug`
+- `dev run --rm shipitron deploy <app> --debug`
 
 To release a new version:
 - Update the version number in `version.rb` and `Dockerfile.release` and commit the result.

--- a/build_env/docker-config.json
+++ b/build_env/docker-config.json
@@ -1,0 +1,3 @@
+{
+  "credsStore": "ecr-login"
+}

--- a/build_env/docker-config.json
+++ b/build_env/docker-config.json
@@ -1,3 +1,0 @@
-{
-  "credsStore": "ecr-login"
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  shipitron:
+    image: outstand/shipitron:dev
+    environment:
+      FOG_LOCAL: 'true'
+      APP_PATH: ~/dev/pages
+    working_dir: /shipitron
+    volumes:
+      - ~/dev/pages:/app
+      - fog:/fog
+      - shipitron-home:/home/shipitron
+      - ~/.config/shipitron:/home/shipitron/.config/shipitron
+      - .:/shipitron
+
+volumes:
+  fog:
+  shipitron-home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,19 @@ services:
   shipitron:
     image: outstand/shipitron:dev
     environment:
-      FOG_LOCAL: 'true'
       APP_PATH: ~/dev/pages
-    working_dir: /shipitron
     volumes:
       - ~/dev/pages:/app
+      - shipitron-home:/home/shipitron
+      - ~/.config/shipitron:/home/shipitron/.config/shipitron
+      - .:/shipitron
+  shipitron_specs:
+    image: outstand/shipitron:dev
+    command: rspec spec
+    environment:
+      FOG_LOCAL: 'true'
+    working_dir: /shipitron
+    volumes:
       - fog:/fog
       - shipitron-home:/home/shipitron
       - ~/.config/shipitron:/home/shipitron/.config/shipitron

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,8 @@ version: '3.8'
 services:
   shipitron:
     image: outstand/shipitron:dev
-    environment:
-      APP_PATH: ~/dev/pages
     volumes:
-      - ~/dev/pages:/app
+      - ~/dev/pages:/app # Set this to the application to be shipitron'd
       - shipitron-home:/home/shipitron
       - ~/.config/shipitron:/home/shipitron/.config/shipitron
       - .:/shipitron

--- a/lib/shipitron/cli.rb
+++ b/lib/shipitron/cli.rb
@@ -66,7 +66,7 @@ module Shipitron
     option :build_cache_location, default: 'tmp/build-cache.tar.gz'
     option :image_name, required: true
     option :named_tag, default: 'latest'
-    option :skip_push, default: false
+    option :skip_push, type: :boolean, default: false
     option :region, required: true
     option :clusters, type: :array, required: true
     option :ecs_task_defs, type: :array, required: true

--- a/lib/shipitron/cli.rb
+++ b/lib/shipitron/cli.rb
@@ -62,6 +62,7 @@ module Shipitron
     option :name, required: true
     option :repository, required: true
     option :repository_branch, default: 'master'
+    option :registry, default: nil
     option :bucket, required: true
     option :build_cache_location, default: 'tmp/build-cache.tar.gz'
     option :image_name, required: true
@@ -87,6 +88,7 @@ module Shipitron
         application: options[:name],
         repository_url: options[:repository],
         repository_branch: options[:repository_branch],
+        registry: options[:registry],
         s3_cache_bucket: options[:bucket],
         build_cache_location: options[:build_cache_location],
         image_name: options[:image_name],

--- a/lib/shipitron/cli.rb
+++ b/lib/shipitron/cli.rb
@@ -27,7 +27,7 @@ module Shipitron
       )
 
       if result.failure?
-        result.errors.each do |error|
+        result.error_messages.each do |error|
           Logger.fatal error
         end
         Logger.fatal 'Deploy failed.'
@@ -50,7 +50,7 @@ module Shipitron
       )
 
       if result.failure?
-        result.errors.each do |error|
+        result.error_messages.each do |error|
           Logger.fatal error
         end
         Logger.fatal 'Deploy failed.'
@@ -108,7 +108,7 @@ module Shipitron
       )
 
       if result.failure?
-        result.errors.each do |error|
+        result.error_messages.each do |error|
           Logger.fatal error
         end
         Logger.fatal 'Deploy failed.'
@@ -139,7 +139,7 @@ module Shipitron
       )
 
       if result.failure?
-        result.errors.each do |error|
+        result.error_messages.each do |error|
           Logger.fatal error
         end
         Logger.fatal 'Bootstrap failed.'

--- a/lib/shipitron/cli.rb
+++ b/lib/shipitron/cli.rb
@@ -66,6 +66,7 @@ module Shipitron
     option :build_cache_location, default: 'tmp/build-cache.tar.gz'
     option :image_name, required: true
     option :named_tag, default: 'latest'
+    option :skip_push, default: false
     option :region, required: true
     option :clusters, type: :array, required: true
     option :ecs_task_defs, type: :array, required: true
@@ -90,6 +91,7 @@ module Shipitron
         build_cache_location: options[:build_cache_location],
         image_name: options[:image_name],
         named_tag: options[:named_tag],
+        skip_push: options[:skip_push],
         region: options[:region],
         clusters: options[:clusters],
         ecs_task_defs: options[:ecs_task_defs],

--- a/lib/shipitron/client.rb
+++ b/lib/shipitron/client.rb
@@ -2,6 +2,6 @@ require 'shipitron'
 
 module Shipitron
   module Client
-    STARTED_BY = 'shipitron'
+    STARTED_BY = 'shipitron-dev'
   end
 end

--- a/lib/shipitron/client.rb
+++ b/lib/shipitron/client.rb
@@ -2,6 +2,8 @@ require 'shipitron'
 
 module Shipitron
   module Client
-    STARTED_BY = 'shipitron-dev'
+    STARTED_BY = 'shipitron'
+    # Use this for testing.
+    # STARTED_BY = 'shipitron-dev'
   end
 end

--- a/lib/shipitron/client.rb
+++ b/lib/shipitron/client.rb
@@ -1,0 +1,7 @@
+require 'shipitron'
+
+module Shipitron
+  module Client
+    STARTED_BY = 'shipitron'
+  end
+end

--- a/lib/shipitron/client/bootstrap_application.rb
+++ b/lib/shipitron/client/bootstrap_application.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/client/register_ecs_task_definitions'
 require 'shipitron/client/create_ecs_services'
 

--- a/lib/shipitron/client/create_ecs_services.rb
+++ b/lib/shipitron/client/create_ecs_services.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/ecs_client'
 require 'shipitron/mustache_yaml_parser'
 require 'securerandom'

--- a/lib/shipitron/client/deploy_application.rb
+++ b/lib/shipitron/client/deploy_application.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/client/load_application_config'
 require 'shipitron/client/load_templates'
 require 'shipitron/client/fetch_clusters'

--- a/lib/shipitron/client/ensure_deploy_not_running.rb
+++ b/lib/shipitron/client/ensure_deploy_not_running.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/ecs_client'
 
 # Note: This is a best effort client side check to make sure there
@@ -21,7 +22,7 @@ module Shipitron
             begin
               response = ecs_client(region: cluster.region).list_tasks(
                 cluster: cluster.name,
-                started_by: 'shipitron',
+                started_by: Shipitron::Client::STARTED_BY,
                 max_results: 1,
                 desired_status: status
               )

--- a/lib/shipitron/client/fetch_clusters.rb
+++ b/lib/shipitron/client/fetch_clusters.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'resolv'
 
 module Shipitron

--- a/lib/shipitron/client/force_deploy.rb
+++ b/lib/shipitron/client/force_deploy.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/ecs_client'
 require 'shipitron/client/load_application_config'
 require 'shipitron/client/fetch_clusters'

--- a/lib/shipitron/client/load_application_config.rb
+++ b/lib/shipitron/client/load_application_config.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/post_build'
 
 module Shipitron

--- a/lib/shipitron/client/load_application_config.rb
+++ b/lib/shipitron/client/load_application_config.rb
@@ -21,6 +21,7 @@ module Shipitron
                                 config.named_tag
                               end
                             end
+        context.skip_push = config.skip_push
         context.build_script = config.build_script
         context.post_builds = begin
                                 if config.post_builds.nil?

--- a/lib/shipitron/client/load_application_config.rb
+++ b/lib/shipitron/client/load_application_config.rb
@@ -12,6 +12,7 @@ module Shipitron
       def call
         context.repository_url = config.repository
         context.repository_branch = config.repository_branch
+        context.registry = config.registry
         context.s3_cache_bucket = config.cache_bucket
         context.build_cache_location = config.build_cache_location
         context.image_name = config.image_name

--- a/lib/shipitron/client/load_templates.rb
+++ b/lib/shipitron/client/load_templates.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 
 module Shipitron
   module Client

--- a/lib/shipitron/client/register_ecs_task_definitions.rb
+++ b/lib/shipitron/client/register_ecs_task_definitions.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/ecs_client'
 require 'shipitron/mustache_yaml_parser'
 

--- a/lib/shipitron/client/run_ecs_tasks.rb
+++ b/lib/shipitron/client/run_ecs_tasks.rb
@@ -131,7 +131,7 @@ module Shipitron
           end
 
           if context.skip_push != nil
-            ary.concat ['--skip-push', context.skip_push]
+            ary.concat ['--skip-push', context.skip_push.to_s]
           end
 
           if !context.post_builds.empty?

--- a/lib/shipitron/client/run_ecs_tasks.rb
+++ b/lib/shipitron/client/run_ecs_tasks.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'shipitron/client'
 require 'shipitron/ecs_client'
 require 'shellwords'
 require 'base64'
@@ -74,7 +75,7 @@ module Shipitron
               ]
             },
             count: 1,
-            started_by: 'shipitron'
+            started_by: Shipitron::Client::STARTED_BY
           )
 
           if !response.failures.empty?

--- a/lib/shipitron/client/run_ecs_tasks.rb
+++ b/lib/shipitron/client/run_ecs_tasks.rb
@@ -24,6 +24,7 @@ module Shipitron
       optional :ecs_services
       optional :ecs_service_templates
       optional :build_script
+      optional :skip_push
       optional :post_builds
       optional :simulate
       optional :repository_branch
@@ -127,6 +128,10 @@ module Shipitron
 
           if context.build_script != nil
             ary.concat ['--build-script', context.build_script]
+          end
+
+          if context.skip_push != nil
+            ary.concat ['--skip-push', context.skip_push]
           end
 
           if !context.post_builds.empty?

--- a/lib/shipitron/client/run_ecs_tasks.rb
+++ b/lib/shipitron/client/run_ecs_tasks.rb
@@ -29,6 +29,7 @@ module Shipitron
       optional :post_builds
       optional :simulate
       optional :repository_branch
+      optional :registry
 
       before do
         context.post_builds ||= []
@@ -125,6 +126,10 @@ module Shipitron
           unless context.ecs_services.empty?
             ary << '--ecs-services'
             ary.concat(context.ecs_services)
+          end
+
+          if context.registry != nil
+            ary.concat ['--registry', context.registry]
           end
 
           if context.build_script != nil

--- a/lib/shipitron/docker_image.rb
+++ b/lib/shipitron/docker_image.rb
@@ -2,6 +2,7 @@ require 'shipitron'
 
 module Shipitron
   class DockerImage < Hashie::Dash
+    property :registry
     property :name
     property :tag
 
@@ -13,7 +14,9 @@ module Shipitron
         tag_str = tag_str.dup.prepend(':')
       end
 
-      "#{name}#{tag_str}"
+      name_with_registry = [registry, name].compact.join('/')
+
+      "#{name_with_registry}#{tag_str}"
     end
 
     def to_s

--- a/lib/shipitron/find_docker_volume_name.rb
+++ b/lib/shipitron/find_docker_volume_name.rb
@@ -1,0 +1,68 @@
+require 'excon'
+require 'json'
+
+module Shipitron
+  class FindDockerVolumeName
+    include Metaractor
+
+    required :container_name
+    required :volume_search
+
+    def call
+      volumes = container_volumes(container_name: container_name)
+
+      volume_metadata = volumes.find do |volume|
+        volume['DockerName'] =~ volume_search
+      end
+
+      if volume_metadata.nil?
+        raise 'Unable to find shipitron-home volume!'
+      end
+
+      context.volume_name = volume_metadata['DockerName']
+    end
+
+    private
+    def container_name
+      context.container_name
+    end
+
+    def volume_search
+      context.volume_search
+    end
+
+    def container_volumes(container_name:)
+      container_metadata = self.task_metadata['Containers'].find do |container|
+        container['Name'] == container_name
+      end
+
+      return {} if container_metadata.nil?
+
+      container_metadata['Volumes']
+    end
+
+    def task_metadata
+      return @task_metadata if defined?(@task_metadata)
+
+      begin
+        response = Excon.get(
+          "#{ENV['ECS_CONTAINER_METADATA_URI_V4']}/task",
+          expects: [200],
+          connect_timeout: 5,
+          read_timeout: 5,
+          write_timeout: 5,
+          tcp_nodelay: true
+        )
+
+        Logger.debug "Metadata result:"
+        Logger.debug(response.body)
+        Logger.debug "\n"
+
+        @task_metadata = JSON.parse(response.body)
+      rescue
+        Logger.info "Metadata uri failed"
+        {}
+      end
+    end
+  end
+end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -15,7 +15,7 @@ module Shipitron
           fail_with_error!(message: 'Failed to transfer to/from s3 (mocked).')
         end
       else
-        Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron -e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
+        Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron -e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination} --quiet --only-show-errors`
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')
         end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -1,0 +1,34 @@
+require 'shipitron'
+
+module Shipitron
+  class S3Copy
+    include Metaractor
+
+    required :source
+    required :destination
+
+    def call
+      if ENV['FOG_LOCAL']
+        Logger.info `cp #{source.gsub('s3://', '/fog/')} #{destination.gsub('s3://', '/fog/')}`
+        if $? != 0
+          fail_with_error!('Failed to transfer to/from s3 (mocked).')
+        end
+      else
+        # TODO: Deal with docker mounting from the host but we're in a container already
+        Logger.info `docker run --rm -it amazon/aws-cli:latest s3 cp #{source} #{destination}`
+        if $? != 0
+          fail_with_error!('Failed to transfer to/from s3.')
+        end
+      end
+    end
+
+    private
+    def source
+      context.source
+    end
+
+    def destination
+      context.destination
+    end
+  end
+end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -15,8 +15,7 @@ module Shipitron
           fail_with_error!(message: 'Failed to transfer to/from s3 (mocked).')
         end
       else
-        # TODO: Deal with docker mounting from the host but we're in a container already
-        Logger.info `docker run --rm -it amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
+        Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')
         end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -20,6 +20,8 @@ module Shipitron
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')
         end
+
+        Logger.info "S3 result: #{Pathname.new(destination).parent.children.inspect}"
       end
     end
 

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -27,8 +27,6 @@ module Shipitron
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')
         end
-
-        Logger.info "S3 result: #{Pathname.new(destination).parent.children.inspect}"
       end
     end
 

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -12,13 +12,13 @@ module Shipitron
       if ENV['FOG_LOCAL']
         Logger.info `cp #{source.gsub('s3://', '/fog/')} #{destination.gsub('s3://', '/fog/')}`
         if $? != 0
-          fail_with_error!('Failed to transfer to/from s3 (mocked).')
+          fail_with_error!(message: 'Failed to transfer to/from s3 (mocked).')
         end
       else
         # TODO: Deal with docker mounting from the host but we're in a container already
         Logger.info `docker run --rm -it amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
         if $? != 0
-          fail_with_error!('Failed to transfer to/from s3.')
+          fail_with_error!(message: 'Failed to transfer to/from s3.')
         end
       end
     end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -15,7 +15,7 @@ module Shipitron
           fail_with_error!(message: 'Failed to transfer to/from s3 (mocked).')
         end
       else
-        Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
+        Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron -e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')
         end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -6,6 +6,7 @@ module Shipitron
 
     required :source
     required :destination
+    required :region
 
     def call
       if ENV['FOG_LOCAL']
@@ -15,7 +16,7 @@ module Shipitron
         end
       else
         # TODO: Deal with docker mounting from the host but we're in a container already
-        Logger.info `docker run --rm -it amazon/aws-cli:latest s3 cp #{source} #{destination}`
+        Logger.info `docker run --rm -it amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination}`
         if $? != 0
           fail_with_error!('Failed to transfer to/from s3.')
         end
@@ -29,6 +30,10 @@ module Shipitron
 
     def destination
       context.destination
+    end
+
+    def region
+      context.region
     end
   end
 end

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -16,6 +16,7 @@ module Shipitron
         end
       else
         Logger.info "S3 Copy from #{source} to #{destination}"
+        Logger.info `curl ${ECS_CONTAINER_METADATA_URI_V4}/task`
         Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron -e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination} --quiet --only-show-errors`
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')

--- a/lib/shipitron/s3_copy.rb
+++ b/lib/shipitron/s3_copy.rb
@@ -15,6 +15,7 @@ module Shipitron
           fail_with_error!(message: 'Failed to transfer to/from s3 (mocked).')
         end
       else
+        Logger.info "S3 Copy from #{source} to #{destination}"
         Logger.info `docker run --rm -t -v shipitron-home:/home/shipitron -e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI amazon/aws-cli:latest --region #{region} s3 cp #{source} #{destination} --quiet --only-show-errors`
         if $? != 0
           fail_with_error!(message: 'Failed to transfer to/from s3.')

--- a/lib/shipitron/server/deploy_application.rb
+++ b/lib/shipitron/server/deploy_application.rb
@@ -31,6 +31,7 @@ module Shipitron
       optional :build_script
       optional :post_builds
       optional :repository_branch
+      optional :skip_push, default: false
 
       around do |interactor|
         if ENV['CONSUL_HOST'].nil?

--- a/lib/shipitron/server/deploy_application.rb
+++ b/lib/shipitron/server/deploy_application.rb
@@ -32,6 +32,7 @@ module Shipitron
       optional :post_builds
       optional :repository_branch
       optional :skip_push, default: false
+      optional :registry
 
       around do |interactor|
         if ENV['CONSUL_HOST'].nil?

--- a/lib/shipitron/server/docker/build_image.rb
+++ b/lib/shipitron/server/docker/build_image.rb
@@ -14,6 +14,7 @@ module Shipitron
         required :docker_image
         required :git_sha
         required :named_tag
+        optional :registry
 
         organize [
           DownloadBuildCache,

--- a/lib/shipitron/server/docker/build_image.rb
+++ b/lib/shipitron/server/docker/build_image.rb
@@ -14,6 +14,7 @@ module Shipitron
         required :docker_image
         required :git_sha
         required :named_tag
+        required :region
         optional :registry
 
         organize [

--- a/lib/shipitron/server/docker/build_image.rb
+++ b/lib/shipitron/server/docker/build_image.rb
@@ -13,6 +13,7 @@ module Shipitron
         required :application
         required :docker_image
         required :git_sha
+        required :named_tag
 
         organize [
           DownloadBuildCache,

--- a/lib/shipitron/server/docker/configure.rb
+++ b/lib/shipitron/server/docker/configure.rb
@@ -35,15 +35,20 @@ module Shipitron
               # ECR
               config_file = Pathname.new('/home/shipitron/.docker/config.json')
               config_file.parent.mkpath
-              config_file.open('r+b') do |file|
-                json = file.read
-                hash = JSON.parse(json) rescue {}
-                hash['credHelpers'] ||= {}
-                hash['credHelpers'][registry] = 'ecr-login'
 
-                file.rewind
-                file.puts(JSON.generate(hash))
-                file.truncate(file.pos)
+              config_hash = {}
+              if config_file.file?
+                config_file.open('rb') do |file|
+                  json = file.read
+                  config_hash = JSON.parse(json) rescue {}
+                end
+              end
+
+              config_hash['credHelpers'] ||= {}
+              config_hash['credHelpers'][registry] = 'ecr-login'
+
+              config_file.open('wb') do |file|
+                file.puts(JSON.generate(config_hash))
                 file.chmod(0600)
               end
             end
@@ -61,7 +66,7 @@ module Shipitron
 
         def fetch_scoped_key(key)
           value = fetch_key(key: "shipitron/#{application}/#{key}")
-          value = fetch_key!(key: "shipitron/#{key}") if value.nil?
+          value = fetch_key(key: "shipitron/#{key}") if value.nil?
           value
         end
       end

--- a/lib/shipitron/server/docker/configure.rb
+++ b/lib/shipitron/server/docker/configure.rb
@@ -41,7 +41,7 @@ module Shipitron
                 hash['credHelpers'] ||= {}
                 hash['credHelpers'][registry] = 'ecr-login'
 
-                file.truncate
+                file.truncate(0)
                 file.puts(JSON.generate(hash))
                 file.chmod(0600)
               end

--- a/lib/shipitron/server/docker/configure.rb
+++ b/lib/shipitron/server/docker/configure.rb
@@ -15,13 +15,14 @@ module Shipitron
         end
 
         def call
-          username = fetch_scoped_key('docker_user')
-          password = fetch_scoped_key('docker_password')
-
-          Logger.info `docker login --username #{username} --password #{password}`
-          if $? != 0
-            fail_with_error!(message: 'Docker login failed.')
-          end
+          return # try no-op
+          # username = fetch_scoped_key('docker_user')
+          # password = fetch_scoped_key('docker_password')
+          #
+          # Logger.info `docker login --username #{username} --password #{password}`
+          # if $? != 0
+          #   fail_with_error!(message: 'Docker login failed.')
+          # end
         end
 
         private

--- a/lib/shipitron/server/docker/configure.rb
+++ b/lib/shipitron/server/docker/configure.rb
@@ -1,5 +1,6 @@
 require 'shipitron'
 require 'shipitron/consul_keys'
+require 'json'
 
 module Shipitron
   module Server
@@ -9,20 +10,43 @@ module Shipitron
         include ConsulKeys
 
         required :application
+        optional :registry
 
         before do
           configure_consul_client!
         end
 
         def call
-          return # try no-op
-          # username = fetch_scoped_key('docker_user')
-          # password = fetch_scoped_key('docker_password')
-          #
-          # Logger.info `docker login --username #{username} --password #{password}`
-          # if $? != 0
-          #   fail_with_error!(message: 'Docker login failed.')
-          # end
+          username = fetch_scoped_key('docker_user')
+          password = fetch_scoped_key('docker_password')
+
+          if username && password
+            Logger.info `docker login --username #{username} --password #{password}`
+            if $? != 0
+              fail_with_error!(message: 'Docker login failed.')
+            end
+          end
+
+          if registry
+            case registry
+            when /docker\.io/
+              # do nothing
+            when /\d+\.dkr\.ecr\.us-east-1\.amazonaws\.com/
+              # ECR
+              config_file = Pathname.new('/home/shipitron/.docker/config.json')
+              config_file.parent.mkpath
+              config_file.open('r+b') do |file|
+                json = file.read
+                hash = JSON.parse(json) rescue {}
+                hash['credHelpers'] ||= {}
+                hash['credHelpers'][registry] = 'ecr-login'
+
+                file.truncate
+                file.puts(JSON.generate(hash))
+                file.chmod(0600)
+              end
+            end
+          end
         end
 
         private

--- a/lib/shipitron/server/docker/configure.rb
+++ b/lib/shipitron/server/docker/configure.rb
@@ -41,8 +41,9 @@ module Shipitron
                 hash['credHelpers'] ||= {}
                 hash['credHelpers'][registry] = 'ecr-login'
 
-                file.truncate(0)
+                file.rewind
                 file.puts(JSON.generate(hash))
+                file.truncate(file.pos)
                 file.chmod(0600)
               end
             end

--- a/lib/shipitron/server/docker/configure.rb
+++ b/lib/shipitron/server/docker/configure.rb
@@ -54,6 +54,10 @@ module Shipitron
           context.application
         end
 
+        def registry
+          context.registry
+        end
+
         def fetch_scoped_key(key)
           value = fetch_key(key: "shipitron/#{application}/#{key}")
           value = fetch_key!(key: "shipitron/#{key}") if value.nil?

--- a/lib/shipitron/server/docker/push_image.rb
+++ b/lib/shipitron/server/docker/push_image.rb
@@ -8,8 +8,11 @@ module Shipitron
 
         required :docker_image
         required :named_tag
+        optional :skip_push, default: false
 
         def call
+          return if context.skip_push
+
           Logger.info "Pushing docker image #{docker_image} and #{docker_image.name_with_tag(named_tag)}"
 
           Logger.info `docker tag #{docker_image} #{docker_image.name_with_tag(named_tag)}`

--- a/lib/shipitron/server/docker/run_build_script.rb
+++ b/lib/shipitron/server/docker/run_build_script.rb
@@ -12,10 +12,12 @@ module Shipitron
         required :git_sha
         required :named_tag
         optional :build_script, default: 'shipitron/build.sh'
+        optional :registry
 
         def call
           Logger.info 'Building docker image'
 
+          docker_image.registry = registry if registry != nil
           docker_image.tag = git_sha
 
           FileUtils.cd("/home/shipitron/#{application}") do

--- a/lib/shipitron/server/docker/run_build_script.rb
+++ b/lib/shipitron/server/docker/run_build_script.rb
@@ -54,6 +54,10 @@ module Shipitron
         def build_script
           context.build_script
         end
+
+        def registry
+          context.registry
+        end
       end
     end
   end

--- a/lib/shipitron/server/docker/run_build_script.rb
+++ b/lib/shipitron/server/docker/run_build_script.rb
@@ -10,11 +10,8 @@ module Shipitron
         required :application
         required :docker_image
         required :git_sha
-        optional :build_script
-
-        before do
-          context.build_script ||= 'shipitron/build.sh'
-        end
+        required :named_tag
+        optional :build_script, default: 'shipitron/build.sh'
 
         def call
           Logger.info 'Building docker image'
@@ -27,7 +24,7 @@ module Shipitron
             end
 
             cmd = TTY::Command.new
-            result = cmd.run!("#{build_script} #{docker_image}")
+            result = cmd.run!("#{build_script} #{docker_image} #{named_tag}")
 
             if result.failure?
               fail_with_error!(message: "build script exited with non-zero code: #{result.exit_status}")
@@ -46,6 +43,10 @@ module Shipitron
 
         def git_sha
           context.git_sha
+        end
+
+        def named_tag
+          context.named_tag
         end
 
         def build_script

--- a/lib/shipitron/server/download_build_cache.rb
+++ b/lib/shipitron/server/download_build_cache.rb
@@ -9,6 +9,7 @@ module Shipitron
       required :application
       required :s3_cache_bucket
       required :build_cache_location
+      required :region
 
       def call
         Logger.info "Downloading build cache from bucket #{s3_cache_bucket}"
@@ -24,7 +25,8 @@ module Shipitron
 
         result = S3Copy.call(
           source: "s3://#{s3_cache_bucket}/#{application}.build-cache.archive",
-          destination: build_cache.to_s
+          destination: build_cache.to_s,
+          region: context.region
         )
         if result.failure?
           fail_with_error!(message: 'Failed to download build cache!')

--- a/lib/shipitron/server/download_build_cache.rb
+++ b/lib/shipitron/server/download_build_cache.rb
@@ -1,5 +1,6 @@
 require 'shipitron'
 require 'shipitron/fetch_bucket'
+require 'shipitron/s3_copy'
 
 module Shipitron
   module Server

--- a/lib/shipitron/server/download_build_cache.rb
+++ b/lib/shipitron/server/download_build_cache.rb
@@ -21,10 +21,13 @@ module Shipitron
 
         build_cache = Pathname.new("/home/shipitron/#{application}/#{build_cache_location}")
         build_cache.parent.mkpath
-        build_cache.open('wb') do |local_file|
-          bucket.files.get("#{application}.build-cache.archive") do |chunk, _remaining_bytes, _total_bytes|
-            local_file.write(chunk)
-          end
+
+        result = S3Copy.call(
+          source: "s3://#{s3_cache_bucket}/#{application}.build-cache.archive",
+          destination: build_cache.to_s
+        )
+        if result.failure?
+          fail_with_error!(message: 'Failed to download build cache!')
         end
 
         Logger.info 'Download complete.'

--- a/lib/shipitron/server/transform_cli_args.rb
+++ b/lib/shipitron/server/transform_cli_args.rb
@@ -12,6 +12,7 @@ module Shipitron
       required :application
       required :repository_url
       optional :repository_branch
+      optional :registry
       required :s3_cache_bucket
       required :build_cache_location
       required :image_name
@@ -38,6 +39,7 @@ module Shipitron
           application
           repository_url
           repository_branch
+          registry
           s3_cache_bucket
           build_cache_location
           named_tag

--- a/lib/shipitron/server/transform_cli_args.rb
+++ b/lib/shipitron/server/transform_cli_args.rb
@@ -23,6 +23,7 @@ module Shipitron
       optional :ecs_services
       optional :ecs_service_templates
       optional :build_script
+      optional :skip_push, default: false
       optional :post_builds
 
       before do
@@ -44,6 +45,7 @@ module Shipitron
           clusters
           ecs_services
           build_script
+          skip_push
         ].each_with_object(cli_args) { |k, args| args[k] = context[k] }
 
         cli_args.docker_image = DockerImage.new(name: context.image_name)

--- a/lib/shipitron/server/update_ecs_task_definitions.rb
+++ b/lib/shipitron/server/update_ecs_task_definitions.rb
@@ -14,11 +14,12 @@ module Shipitron
       required :docker_image
       required :ecs_task_defs
       optional :ecs_task_def_templates
+      optional :registry
 
       before do
         context.ecs_task_def_templates ||= []
         context.templates = context.ecs_task_def_templates
-        context.template_context = { tag: docker_image.tag }
+        context.template_context = { tag: docker_image.tag, registry: context.registry }
       end
 
       organize [

--- a/lib/shipitron/server/upload_build_cache.rb
+++ b/lib/shipitron/server/upload_build_cache.rb
@@ -22,7 +22,7 @@ module Shipitron
         build_cache.open('rb') do |local_file|
           bucket.files.create(
             key: "#{application}.build-cache.archive",
-            body: local_file.read
+            body: local_file
           )
         end
       end

--- a/lib/shipitron/server/upload_build_cache.rb
+++ b/lib/shipitron/server/upload_build_cache.rb
@@ -9,6 +9,7 @@ module Shipitron
       required :application
       required :s3_cache_bucket
       required :build_cache_location
+      required :region
 
       def call
         Logger.info "Uploading build cache to bucket #{s3_cache_bucket}"
@@ -21,7 +22,8 @@ module Shipitron
 
         result = S3Copy.call(
           source: build_cache.to_s,
-          destination: "s3://#{s3_cache_bucket}/#{application}.build-cache.archive"
+          destination: "s3://#{s3_cache_bucket}/#{application}.build-cache.archive",
+          region: context.region
         )
         if result.failure?
           Logger.warn 'Failed to upload build cache!'

--- a/lib/shipitron/server/upload_build_cache.rb
+++ b/lib/shipitron/server/upload_build_cache.rb
@@ -25,6 +25,8 @@ module Shipitron
         )
         if result.failure?
           Logger.warn 'Failed to upload build cache!'
+        else
+          Logger.info 'Upload complete.'
         end
       end
 

--- a/lib/shipitron/server/upload_build_cache.rb
+++ b/lib/shipitron/server/upload_build_cache.rb
@@ -19,11 +19,12 @@ module Shipitron
           return
         end
 
-        build_cache.open('rb') do |local_file|
-          bucket.files.create(
-            key: "#{application}.build-cache.archive",
-            body: local_file
-          )
+        result = S3Copy.call(
+          source: build_cache.to_s,
+          destination: "s3://#{s3_cache_bucket}/#{application}.build-cache.archive"
+        )
+        if result.failure?
+          Logger.warn 'Failed to upload build cache!'
         end
       end
 
@@ -38,10 +39,6 @@ module Shipitron
 
       def build_cache_location
         context.build_cache_location
-      end
-
-      def bucket
-        @bucket ||= FetchBucket.call!(name: s3_cache_bucket).bucket
       end
     end
   end

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+chown_dir() {
+  dir=$1
+  if [ "$(stat -c %u ${dir})" = '0' ]; then
+    chown -R shipitron:shipitron $dir
+  fi
+}
+
+chown_dir /home/shipitron
+
 if [ -n "$USE_BUNDLE_EXEC" ]; then
   BINARY="bundle exec shipitron"
 else

--- a/shipitron.gemspec
+++ b/shipitron.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-command', '~> 0.7'
   spec.add_runtime_dependency 'tty-table', '~> 0.9'
   spec.add_runtime_dependency 'pastel', '~> 0.7'
-  spec.add_runtime_dependency 'docker-api', '~> 2.0.0.pre.1'
+  spec.add_runtime_dependency 'excon', '~> 0.76'
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "pry-byebug", "~> 3.5"
   spec.add_development_dependency "rspec", "~> 3.7"

--- a/shipitron.gemspec
+++ b/shipitron.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-command', '~> 0.7'
   spec.add_runtime_dependency 'tty-table', '~> 0.9'
   spec.add_runtime_dependency 'pastel', '~> 0.7'
+  spec.add_runtime_dependency 'docker-api', '~> 2.0.0.pre.1'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/shipitron.gemspec
+++ b/shipitron.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'thor', '~> 0.20'
+  spec.add_runtime_dependency 'thor', '~> 1.0'
   spec.add_runtime_dependency 'aws-sdk-ecs', '~> 1.8'
-  spec.add_runtime_dependency 'hashie', '~> 3.5'
-  spec.add_runtime_dependency 'metaractor', '~> 0.5'
+  spec.add_runtime_dependency 'hashie', '~> 4.1'
+  spec.add_runtime_dependency 'metaractor', '~> 3.0'
   spec.add_runtime_dependency 'diplomat', '~> 2.0'
-  spec.add_runtime_dependency 'fog-aws', '~> 2.0'
+  spec.add_runtime_dependency 'fog-aws', '~> 3.6'
   spec.add_runtime_dependency 'mime-types', '~> 3.1'
   spec.add_runtime_dependency 'minitar', '~> 0.6'
   spec.add_runtime_dependency 'mustache', '~> 1.0'
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pastel', '~> 0.7'
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "pry-byebug", "~> 3.5"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "fivemat", "~> 1.3"

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -3,6 +3,7 @@ applications:
   dummy-app:
     repository: git@github.com:outstand/dummy-app
     cache_bucket: outstand-shipitron
+    build_cache_location: tmp/build-cache.tar.gz
     image_name: outstand/dummy-app
     build_script: shipitron/build.sh
     post_builds:

--- a/spec/unit/find_docker_volume_name_spec.rb
+++ b/spec/unit/find_docker_volume_name_spec.rb
@@ -1,0 +1,33 @@
+require 'shipitron/find_docker_volume_name'
+
+describe Shipitron::FindDockerVolumeName do
+  let(:ecs_container_metadata_uri_v4) { 'http://ecs_container_metadata_uri_v4' }
+  let(:task_metadata_response) do
+    '{"Cluster":"us-east-1-prod-blue","TaskARN":"arn:aws:ecs:us-east-1:123456:task/us-east-1-prod-blue/7c4316a685e34f59b581a6b504d5bdc1","Family":"shipitron-dev","Revision":"5","DesiredStatus":"RUNNING","KnownStatus":"RUNNING","PullStartedAt":"2020-08-26T15:31:45.969406698Z","PullStoppedAt":"2020-08-26T15:31:59.96520262Z","AvailabilityZone":"us-east-1e","Containers":[{"DockerId":"da420b5f3376df5deb6b00ced29a5fe3a2c220009edb7c7517eca4f0ef572e7b","Name":"shipitron","DockerName":"ecs-shipitron-dev-5-shipitron-aab6b098c9ceffcc9901","Image":"outstand/shipitron:dev","ImageID":"sha256:65b680a291d0e1f7fddb0dcee4d39eeeea81ac5073317b082f24b184e39bb983","Labels":{"com.amazonaws.ecs.cluster":"us-east-1-prod-blue","com.amazonaws.ecs.container-name":"shipitron","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-east-1:123456:task/us-east-1-prod-blue/7c4316a685e34f59b581a6b504d5bdc1","com.amazonaws.ecs.task-definition-family":"shipitron-dev","com.amazonaws.ecs.task-definition-version":"5"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":768,"Memory":0},"CreatedAt":"2020-08-26T15:32:00.000942732Z","StartedAt":"2020-08-26T15:32:03.726132767Z","Type":"NORMAL","Volumes":[{"Source":"/bin/docker","Destination":"/bin/docker"},{"Source":"/var/run/docker.sock","Destination":"/var/run/docker.sock"},{"DockerName":"ecs-shipitron-dev-5-shipitron-home-dcd984d1a5b3a8a46300","Source":"/var/lib/docker/volumes/ecs-shipitron-dev-5-shipitron-home-dcd984d1a5b3a8a46300/_data","Destination":"/home/shipitron"},{"Source":"/var/lib/ecs/data/metadata/us-east-1-prod-blue/7c4316a685e34f59b581a6b504d5bdc1/shipitron","Destination":"/opt/ecs/metadata/8adb6682-e7a9-41c5-8598-e4ee9085505e"}],"Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.4"]}]}]}'
+  end
+
+  before do
+    ENV['ECS_CONTAINER_METADATA_URI_V4'] = ecs_container_metadata_uri_v4
+    Excon.defaults[:mock] = true
+    Excon.stub(
+      {
+        method: :get,
+        url: "#{ecs_container_metadata_uri_v4}/task"
+      },
+      {
+        body: task_metadata_response,
+        status: 200
+      }
+    )
+  end
+
+  it 'finds the full docker volume name' do
+    result = Shipitron::FindDockerVolumeName.call(
+      container_name: 'shipitron',
+      volume_search: /shipitron-home/
+    )
+
+    expect(result).to be_success
+    expect(result.volume_name).to eq 'ecs-shipitron-dev-5-shipitron-home-dcd984d1a5b3a8a46300'
+  end
+end

--- a/spec/unit/run_ecs_tasks_spec.rb
+++ b/spec/unit/run_ecs_tasks_spec.rb
@@ -10,6 +10,7 @@ describe Shipitron::Client::RunEcsTasks do
   let(:shipitron_task) { 'shipitron' }
   let(:repository_url) { 'git@github.com:outstand/dummy-app' }
   let(:s3_cache_bucket) { 'outstand-shipitron' }
+  let(:build_cache_location) { 'tmp/build-cache.tar.gz' }
   let(:image_name) { 'outstand/dummy-app' }
   let(:named_tag) { 'latest' }
   let(:ecs_task_defs) { ['dummy-app'] }
@@ -21,6 +22,7 @@ describe Shipitron::Client::RunEcsTasks do
       shipitron_task: shipitron_task,
       repository_url: repository_url,
       s3_cache_bucket: s3_cache_bucket,
+      build_cache_location: build_cache_location,
       image_name: image_name,
       named_tag: named_tag,
       ecs_task_defs: ecs_task_defs,
@@ -53,16 +55,9 @@ describe Shipitron::Client::RunEcsTasks do
     )
   end
 
-  it 'runs the task for the green cluster' do
+  it 'does not run the task for the green cluster' do
     action.run!
-    expect(west_ecs_client).to have_received(:run_task).with(
-      hash_including(
-        cluster: 'green',
-        task_definition: shipitron_task,
-        count: 1,
-        started_by: 'shipitron'
-      )
-    )
+    expect(west_ecs_client).to_not have_received(:run_task)
   end
 
   context 'when there is a ServiceError' do

--- a/spec/unit/run_ecs_tasks_spec.rb
+++ b/spec/unit/run_ecs_tasks_spec.rb
@@ -50,7 +50,7 @@ describe Shipitron::Client::RunEcsTasks do
         cluster: 'blue',
         task_definition: shipitron_task,
         count: 1,
-        started_by: 'shipitron'
+        started_by: Shipitron::Client::STARTED_BY
       )
     )
   end


### PR DESCRIPTION
This PR adds both buildkit/buildx support for using those features but also adds ECR support!

### New shipitron config file keys:

- registry (specifies an alternate docker registry):
```yaml
---
applications:
  foobar:
    registry: 12345.dkr.ecr.us-east-1.amazonaws.com
```

- skip_push (shipitron will skip pushing the docker images; use if the build script takes care of this):
```yaml
---
applications:
  foobar:
    skip_push: true
```
Additionally, the build script will receive the named tag in use as `$2`.

### Containerized tool support
Shipitron now supports starting other containers as part of the build process. We're using this to use the aws cli to transfer files to/from s3. Shipitron's task definition needs to have a task scoped docker volume added with the name `shipitron-home`. This volume will be mounted at `/home/shipitron` and should be shared with any new containers:

```
shipitron_home_volume = FindDockerVolumeName.call!(
  container_name: 'shipitron',
  volume_search: /shipitron-home/
).volume_name

docker run ... -v #{shipitron_home_volume}:/home/shipitron ...
```

This allows the containers to share data with each other. ECS will automatically clean up the task scoped container.

If a containerized tool requires access to AWS resources, be sure to pass the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` to it so it can inherit any task roles.