### PR TITLE
AR-916 Add git env vars for post builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /pkg/
 Gemfile.lock
 /tmp/
+/spec/fixtures/test_repo

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+spec/fixtures/test_repo.tgz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 /tmp/
 /cache/
+/spec/fixtures/test_repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN addgroup -S shipitron && \
 
 RUN apk add --no-cache \
     ca-certificates \
-    openssl \
+    openssl-dev \
     tini \
     su-exec \
     build-base \
@@ -25,7 +25,8 @@ RUN apk add --no-cache \
     bash \
     curl \
     wget \
-    jq
+    jq \
+    cmake
 
 ENV ECR_CREDENTIAL_HELPER_VERSION 0.4.0
 RUN cd /usr/local/bin && \

--- a/lib/shipitron/git_info.rb
+++ b/lib/shipitron/git_info.rb
@@ -1,4 +1,5 @@
 require 'shipitron'
+require 'rugged'
 
 module Shipitron
   class GitInfo < Hashie::Dash
@@ -9,14 +10,14 @@ module Shipitron
     property :summary
     property :timestamp
     property :branch
+    property :tag
 
     def one_liner
       "#{name} (#{short_sha}): #{summary}"
     end
 
     def self.from_path(path:)
-      repo = Rugged::Repository.new("/home/shipitron/#{application}")
-      ref = repo.head
+      repo = Rugged::Repository.new(path)
       commit = repo.last_commit
       self.new(
         sha: commit.oid,
@@ -25,8 +26,32 @@ module Shipitron
         name: commit.author.dig(:name),
         summary: commit.summary,
         timestamp: commit.epoch_time,
-        branch: ref.branch? ? ref.name.sub('refs/heads/', '') : ''
+        branch: branch_name(repo: repo),
+        tag: tag_name(repo: repo)
       )
+    end
+
+    def self.branch_name(repo:)
+      ref = repo.head
+      ref.branch? ? ref.name.sub('refs/heads/', '') : ''
+    end
+
+    def self.tag_name(repo:)
+      ref = repo.head
+      tags = repo.tags
+
+      tags.each do |tag|
+        target_id =
+          if tag.annotated?
+            tag.annotation.target_id
+          else
+            tag.target.oid
+          end
+
+        return tag.name if ref.target_id == target_id
+      end
+
+      nil
     end
   end
 end

--- a/lib/shipitron/git_info.rb
+++ b/lib/shipitron/git_info.rb
@@ -11,7 +11,7 @@ module Shipitron
     property :branch
 
     def one_liner
-      "#{name} (#{short_sha}): #{message}"
+      "#{name} (#{short_sha}): #{summary}"
     end
 
     def self.from_path(path:)

--- a/lib/shipitron/git_info.rb
+++ b/lib/shipitron/git_info.rb
@@ -25,7 +25,7 @@ module Shipitron
         email: commit.author.dig(:email),
         name: commit.author.dig(:name),
         summary: commit.summary,
-        timestamp: commit.epoch_time,
+        timestamp: commit.epoch_time.to_s,
         branch: branch_name(repo: repo),
         tag: tag_name(repo: repo)
       )

--- a/lib/shipitron/git_info.rb
+++ b/lib/shipitron/git_info.rb
@@ -1,0 +1,32 @@
+require 'shipitron'
+
+module Shipitron
+  class GitInfo < Hashie::Dash
+    property :sha
+    property :short_sha
+    property :email
+    property :name
+    property :summary
+    property :timestamp
+    property :branch
+
+    def one_liner
+      "#{name} (#{short_sha}): #{message}"
+    end
+
+    def self.from_path(path:)
+      repo = Rugged::Repository.new("/home/shipitron/#{application}")
+      ref = repo.head
+      commit = repo.last_commit
+      self.new(
+        sha: commit.oid,
+        short_sha: commit.oid[0, 12],
+        email: commit.author.dig(:email),
+        name: commit.author.dig(:name),
+        summary: commit.summary,
+        timestamp: commit.epoch_time,
+        branch: ref.branch? ? ref.name.sub('refs/heads/', '') : ''
+      )
+    end
+  end
+end

--- a/lib/shipitron/git_info.rb
+++ b/lib/shipitron/git_info.rb
@@ -33,7 +33,7 @@ module Shipitron
 
     def self.branch_name(repo:)
       ref = repo.head
-      ref.branch? ? ref.name.sub('refs/heads/', '') : ''
+      ref.branch? ? ref.name.sub('refs/heads/', '') : nil
     end
 
     def self.tag_name(repo:)

--- a/lib/shipitron/server/docker/build_image.rb
+++ b/lib/shipitron/server/docker/build_image.rb
@@ -12,7 +12,7 @@ module Shipitron
 
         required :application
         required :docker_image
-        required :git_sha
+        required :git_info
         required :named_tag
         required :region
         optional :registry

--- a/lib/shipitron/server/docker/run_build_script.rb
+++ b/lib/shipitron/server/docker/run_build_script.rb
@@ -9,7 +9,7 @@ module Shipitron
 
         required :application
         required :docker_image
-        required :git_sha
+        required :git_info
         required :named_tag
         optional :build_script, default: 'shipitron/build.sh'
         optional :registry
@@ -18,7 +18,7 @@ module Shipitron
           Logger.info 'Building docker image'
 
           docker_image.registry = registry if registry != nil
-          docker_image.tag = git_sha
+          docker_image.tag = git_info.short_sha
 
           FileUtils.cd("/home/shipitron/#{application}") do
             unless Pathname.new(build_script).exist?
@@ -43,8 +43,8 @@ module Shipitron
           context.docker_image
         end
 
-        def git_sha
-          context.git_sha
+        def git_info
+          context.git_info
         end
 
         def named_tag

--- a/lib/shipitron/server/git/clone_local_copy.rb
+++ b/lib/shipitron/server/git/clone_local_copy.rb
@@ -1,6 +1,5 @@
 require 'shipitron'
 require 'shellwords'
-require 'rugged'
 
 module Shipitron
   module Server

--- a/lib/shipitron/server/git/clone_local_copy.rb
+++ b/lib/shipitron/server/git/clone_local_copy.rb
@@ -1,5 +1,6 @@
 require 'shipitron'
 require 'shellwords'
+require 'shipitron/git_info'
 
 module Shipitron
   module Server

--- a/lib/shipitron/server/git/clone_local_copy.rb
+++ b/lib/shipitron/server/git/clone_local_copy.rb
@@ -1,5 +1,6 @@
 require 'shipitron'
 require 'shellwords'
+require 'rugged'
 
 module Shipitron
   module Server
@@ -22,10 +23,8 @@ module Shipitron
           end
 
           Logger.info 'Using this git commit:'
-          FileUtils.cd("/home/shipitron/#{application}") do
-            context.git_sha = `git rev-parse --short=12 HEAD`.chomp
-            Logger.info `git --no-pager log --format='%aN (%h): %s' -n 1`.chomp
-          end
+          context.git_info = GitInfo.from_path("/home/shipitron/#{application}")
+          Logger.info context.git_info.one_liner
         end
 
         private

--- a/lib/shipitron/server/git/clone_local_copy.rb
+++ b/lib/shipitron/server/git/clone_local_copy.rb
@@ -23,7 +23,7 @@ module Shipitron
           end
 
           Logger.info 'Using this git commit:'
-          context.git_info = GitInfo.from_path("/home/shipitron/#{application}")
+          context.git_info = GitInfo.from_path(path: "/home/shipitron/#{application}")
           Logger.info context.git_info.one_liner
         end
 

--- a/lib/shipitron/server/run_post_build.rb
+++ b/lib/shipitron/server/run_post_build.rb
@@ -9,6 +9,7 @@ module Shipitron
 
       required :region
       required :clusters
+      required :git_info
       optional :post_builds
 
       def call
@@ -26,7 +27,33 @@ module Shipitron
                 container_overrides: [
                   {
                     name: post_build.container_name,
-                    command: post_build.command_ary
+                    command: post_build.command_ary,
+                    environment: [
+                      {
+                        name: "GIT_SHA",
+                        value: git_info.sha
+                      },
+                      {
+                        name: "GIT_EMAIL",
+                        value: git_info.email
+                      },
+                      {
+                        name: "GIT_NAME",
+                        value: git_info.name
+                      },
+                      {
+                        name: "GIT_MESSAGE",
+                        value: git_info.summary
+                      },
+                      {
+                        name: "GIT_TIMESTAMP",
+                        value: git_info.timestamp
+                      },
+                      {
+                        name: "GIT_BRANCH",
+                        value: git_info.branch
+                      }
+                    ]
                   }
                 ]
               },
@@ -74,6 +101,10 @@ module Shipitron
 
       def clusters
         context.clusters
+      end
+
+      def git_info
+        context.git_info
       end
     end
   end

--- a/lib/shipitron/server/run_post_build.rb
+++ b/lib/shipitron/server/run_post_build.rb
@@ -34,6 +34,10 @@ module Shipitron
                         value: git_info.sha
                       },
                       {
+                        name: "GIT_SHORT_SHA",
+                        value: git_info.short_sha
+                      },
+                      {
                         name: "GIT_EMAIL",
                         value: git_info.email
                       },

--- a/lib/shipitron/server/run_post_build.rb
+++ b/lib/shipitron/server/run_post_build.rb
@@ -52,6 +52,10 @@ module Shipitron
                       {
                         name: "GIT_BRANCH",
                         value: git_info.branch
+                      },
+                      {
+                        name: "GIT_TAG",
+                        value: git_info.tag
                       }
                     ]
                   }

--- a/shipitron.gemspec
+++ b/shipitron.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-table', '~> 0.9'
   spec.add_runtime_dependency 'pastel', '~> 0.7'
   spec.add_runtime_dependency 'excon', '~> 0.76'
+  spec.add_runtime_dependency 'rugged', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/spec/fixtures/test_repo.tgz
+++ b/spec/fixtures/test_repo.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0eb9a23f3c2b1fa933168029c2e224f8367bdbca001ff5326ebeaba13caae713
+size 13498

--- a/spec/unit/git_info_spec.rb
+++ b/spec/unit/git_info_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Shipitron::GitInfo do
       expect(git_info.email).to eq 'ryan@ryanschlesinger.com'
       expect(git_info.name).to eq 'Ryan Schlesinger'
       expect(git_info.summary).to eq 'Add bar'
-      expect(git_info.timestamp).to eq 1601476924
+      expect(git_info.timestamp).to eq '1601476924'
       expect(git_info.branch).to eq 'master'
       expect(git_info.tag).to eq 'bar-tag'
 

--- a/spec/unit/git_info_spec.rb
+++ b/spec/unit/git_info_spec.rb
@@ -1,0 +1,32 @@
+require 'shipitron/git_info'
+require 'pathname'
+
+RSpec.describe Shipitron::GitInfo do
+  let(:fixtures_dir) { '/shipitron/spec/fixtures' }
+  let(:repo_dir) { '/shipitron/spec/fixtures/test_repo' }
+
+  before do
+    Dir.chdir(fixtures_dir) do
+      unless Pathname.new(repo_dir).directory?
+        `tar -zxf test_repo.tgz`
+      end
+    end
+  end
+
+  describe '.from_path' do
+    it 'builds a valid git info' do
+      git_info = Shipitron::GitInfo.from_path(path: repo_dir)
+
+      expect(git_info.sha).to eq '3c4252d2ce682afe992d1e1cd21c5302de1add2d'
+      expect(git_info.short_sha).to eq '3c4252d2ce68'
+      expect(git_info.email).to eq 'ryan@ryanschlesinger.com'
+      expect(git_info.name).to eq 'Ryan Schlesinger'
+      expect(git_info.summary).to eq 'Add bar'
+      expect(git_info.timestamp).to eq 1601476924
+      expect(git_info.branch).to eq 'master'
+      expect(git_info.tag).to eq 'bar-tag'
+
+      expect(git_info.one_liner).to eq 'Ryan Schlesinger (3c4252d2ce68): Add bar'
+    end
+  end
+end


### PR DESCRIPTION
Post builds need to have access to the git commit information without necessarily having the entire git repo in the docker image. To this end, we're adding the following environment variables:

```sh
GIT_SHA
GIT_SHORT_SHA
GIT_EMAIL
GIT_NAME
GIT_MESSAGE
GIT_TIMESTAMP
GIT_BRANCH
GIT_TAG
```